### PR TITLE
QA-13686: cleanup - remove URL mapping rule for news

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jahia-module-type>system</jahia-module-type>
         <export-package>org.jahia.modules.seo.rules</export-package>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFBSkBPqviFyhmtkyRYRSXelVa59mAhQ3+F1BlAjFYGL3bS4sFj3C6Btr3w==</jahia-module-signature>
+        <jahia-module-signature>MCwCFHG34Cn8UD6Lik9m5esu7CqeRkK7AhRLgEVcGaza931u5GlrqvZejRA8Rg==</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/src/main/resources/META-INF/rules.drl
+++ b/src/main/resources/META-INF/rules.drl
@@ -22,16 +22,3 @@ rule "Check uniqueness"
     then
         Check URL mapping uniqueness for node
 end
-
-rule "Add auto-generated URL mapping for news item"
-    salience 50
-    when
-        Not in operation import
-        A property jcr:title has been set on a node
-            - the node has the type jnt:news
-    then
-        Log "Adding URL mapping '" + "/news/" + jcrUtils.generateNodeName(propertyValueAsString, 70) + "' for node " + node.getPath() + " in language " + property.getLanguage()
-        Remove URL mappings for node node and language property.getLanguage()
-        Add URL mapping "/news/" + jcrUtils.generateNodeName(propertyValueAsString, 70) for node node and language property.getLanguage()
-end
-


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13686

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Remove URL mapping rule for jnt:news
